### PR TITLE
Use tags in recipes where possible

### DIFF
--- a/src/main/resources/data/extrastorage/recipes/diamond_crafter.json
+++ b/src/main/resources/data/extrastorage/recipes/diamond_crafter.json
@@ -16,7 +16,7 @@
       "item": "extrastorage:neural_processor"
     },
     "d": {
-      "item": "minecraft:chest"
+      "tag": "forge:chests/wooden"
     }
   },
   "result": {

--- a/src/main/resources/data/extrastorage/recipes/gold_crafter.json
+++ b/src/main/resources/data/extrastorage/recipes/gold_crafter.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "a": {
-      "item": "minecraft:gold_block"
+      "tag": "forge:storage_blocks/gold"
     },
     "b": {
       "item": "extrastorage:iron_crafter"
@@ -16,7 +16,7 @@
       "item": "extrastorage:neural_processor"
     },
     "d": {
-      "item": "minecraft:chest"
+      "tag": "forge:chests/wooden"
     }
   },
   "result": {

--- a/src/main/resources/data/extrastorage/recipes/iron_crafter.json
+++ b/src/main/resources/data/extrastorage/recipes/iron_crafter.json
@@ -7,13 +7,13 @@
   ],
   "key": {
     "a": {
-      "item": "minecraft:iron_ingot"
+      "tag": "forge:ingots/iron"
     },
     "b": {
       "tag": "refinedstorage:crafter"
     },
     "c": {
-      "item": "minecraft:chest"
+      "tag": "forge:chests/wooden"
     }
   },
   "result": {

--- a/src/main/resources/data/extrastorage/recipes/netherite_crafter.json
+++ b/src/main/resources/data/extrastorage/recipes/netherite_crafter.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "a": {
-      "item": "minecraft:netherite_block"
+      "tag": "forge:storage_blocks/netherite"
     },
     "b": {
       "item": "extrastorage:diamond_crafter"
@@ -16,7 +16,7 @@
       "item": "extrastorage:neural_processor"
     },
     "d": {
-      "item": "minecraft:chest"
+      "tag": "forge:chests/wooden"
     }
   },
   "result": {

--- a/src/main/resources/data/extrastorage/recipes/raw_neural_processor.json
+++ b/src/main/resources/data/extrastorage/recipes/raw_neural_processor.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "a": {
-      "item": "minecraft:crafting_table"
+      "tag": "forge:workbenches"
     },
     "b": {
       "item": "minecraft:quartz"
@@ -19,7 +19,7 @@
       "item": "refinedstorage:raw_improved_processor"
     },
     "e": {
-      "item": "minecraft:obsidian"
+      "tag": "forge:obsidian"
     },
     "f": {
       "item": "refinedstorage:processor_binding"

--- a/src/main/resources/data/extrastorage/recipes/raw_neural_processor.json
+++ b/src/main/resources/data/extrastorage/recipes/raw_neural_processor.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "a": {
-      "tag": "forge:workbenches"
+      "item": "minecraft:crafting_table"
     },
     "b": {
       "item": "minecraft:quartz"


### PR DESCRIPTION
This allows players to use modded wooden chests in the Crafter recipes
Also changes a few other things to use tags