### PR TITLE
Fix packing tape tags for fluid storage blocks

### DIFF
--- a/src/main/resources/data/packingtape/tags/block_entity_type/blacklist/problematic.json
+++ b/src/main/resources/data/packingtape/tags/block_entity_type/blacklist/problematic.json
@@ -1,10 +1,10 @@
 {
   "replace": false,
   "values": [
-    "extrastorage:block_16384k_fluid",
-    "extrastorage:block_65536k_fluid",
-    "extrastorage:block_262144k_fluid",
-    "extrastorage:block_1048576k_fluid",
+    "extrastorage:block_16384b_fluid",
+    "extrastorage:block_65536b_fluid",
+    "extrastorage:block_262144b_fluid",
+    "extrastorage:block_1048576b_fluid",
     "extrastorage:block_256k",
     "extrastorage:block_1024k",
     "extrastorage:block_4096k",


### PR DESCRIPTION
The `#packingtape:blacklist/problematic` tags reference broken ids.